### PR TITLE
Patch InputService to enable IME

### DIFF
--- a/Projects/PhoenixPE/Components/LogonAsAdmin.script
+++ b/Projects/PhoenixPE/Components/LogonAsAdmin.script
@@ -151,7 +151,7 @@ If,%cb_StartMenuShc%,Equal,True,AddShortcut,StartMenu,%txt_StartMenuFolder%,%txt
 [PatchSessionMgr]
 If,ExistFile,"%TargetSystem32%\lsm.dll",Begin
   Echo,"Patching Local Session Manager..."
-  ShellExecute,Hide,"%Tools%\%HostArch%\binmay.exe","-u #$q%TargetSystem32%\lsm.dll#$q -s 83F90D770AB8B03000000FA3C872 -r 83F90D770AB8B03000000FA3C8EB"
+  Binmay,"-u #$q%TargetSystem32%\lsm.dll#$q -s 83F90D770AB8B03000000FA3C872 -r 83F90D770AB8B03000000FA3C8EB"
   If,Not,#r,Equal,0,Halt,"ERROR: Patching [%TargetSystem32%\lsm.dll] failed. The error returned was [#r]."
 End
 

--- a/Projects/PhoenixPE/Components/RDP.script
+++ b/Projects/PhoenixPE/Components/RDP.script
@@ -276,7 +276,7 @@ RequireDriver,tsgenericusbdriver.inf
 [PatchCredDialogController]
 If,ExistFile,"%TargetSystem32%\Windows.UI.CredDialogController.dll",Begin
   Echo,"Patching Windows.UI.CredDialogController.dll..."
-  ShellExecute,Hide,"%Tools%\%HostArch%\binmay.exe","-u #$q%TargetSystem32%\Windows.UI.CredDialogController.dll#$q -s u:MiniNT -r u:ZiniNT"
+  Binmay,"-u #$q%TargetSystem32%\Windows.UI.CredDialogController.dll#$q -s u:MiniNT -r u:ZiniNT"
   If,Not,#r,Equal,0,Halt,"ERROR: Patching [%TargetSystem32%\Windows.UI.CredDialogController.dll] failed. The error returned was [#r]."
 End
 

--- a/Projects/PhoenixPE/Tweaks/411-IME.script
+++ b/Projects/PhoenixPE/Tweaks/411-IME.script
@@ -177,15 +177,6 @@ If,%SourceVer%,BiggerEqual,10.0.18362,RequireFileEx,AppendList,\Windows\System32
 If,%SourceVer%,BiggerEqual,10.0.20251,RequireFileEx,AppendList,\Windows\System32\ime_textinputhelpers.dll
 If,%SourceVer%,BiggerEqual,10.0.26100,RequireFileEx,AppendList,\Windows\SystemApps\MicrosoftWindows.Client.Core_cw5n1h2txyewy\SystemTray\Assets\AXPIcons.ttf
 
-If,ExistFile,"%TargetSystem32%\InputService.dll",Begin
-  Echo,"Patching InputService..."
-  FileVersion,"%TargetSystem32%\InputService.dll",%InputServiceVersion%
-  If,%InputServiceVersion%,Bigger,10.0.18300,Begin
-    ShellExecute,Hide,"%Tools%\%HostArch%\binmay.exe","-v -u #$q%TargetSystem32%\InputService.dll#$q -s u:MiniNT -r u:NiniNT"
-    If,Not,#r,Equal,0,Echo,"ERROR: Patching [%TargetSystem32%\InputService.dll] failed. IME may not be available. The error returned was [#r].",WARN
-  End
-End
-
 ///////////////////////////////////////////////////////////////////////////////////
 // WoW64 
 
@@ -232,6 +223,17 @@ End
 RequireFileEx,ExtractList
 
 ///////////////////////////////////////////////////////////////////////////////////
+
+// Patching
+If,ExistFile,"%TargetSystem32%\InputService.dll",Begin
+  Echo,"Patching InputService..."
+  FileVersion,"%TargetSystem32%\InputService.dll",%InputServiceVersion%
+  If,%InputServiceVersion%,Bigger,10.0.18300,Begin
+    Binmay,"-u #$q%TargetSystem32%\InputService.dll#$q -s u:MiniNT -r u:NiniNT"
+    If,Not,#r,Equal,0,Echo,"ERROR: Patching [%TargetSystem32%\InputService.dll] failed. IME may not be available. The error returned was [#r].",WARN
+  End
+End
+
 // Registry
 
 Echo,"Registering IME common components..."
@@ -403,6 +405,7 @@ Echo,"Building a list of required files...#$x#$xThis can take awhile, please be 
 
 RequireFileEx,AppendList,\Windows\InputMethod\CHS\ChsPinyin.lex
 RequireFileEx,AppendList,\Windows\InputMethod\CHS\ChsPinyin.lm
+RequireFileEx,AppendList,\Windows\InputMethod\CHS\ChsPinyinStx.lex
 RequireFileEx,AppendList,\Windows\InputMethod\CHS\ChsWubi.lex
 RequireFileEx,AppendList,\Windows\System32\InputMethod\CHS
 RequireFileEx,AppendList,\Windows\System32\MSWB70804.dll
@@ -472,6 +475,10 @@ RegWrite,HKLM,0x1,"Tmp_System\Software\Microsoft\CTF\Assemblies\0x00000804\{3474
 RegWrite,HKLM,0x4,"Tmp_System\Software\Microsoft\CTF\Assemblies\0x00000804\{34745C63-B2F0-4784-8B67-5E12C8701A31}","KeyboardLayout",134481924
 RegWrite,HKLM,0x1,"Tmp_System\Software\Microsoft\CTF\HiddenDummyLayouts",00000804,00000804
 RegWrite,HKLM,0x4,"Tmp_System\Software\Microsoft\CTF\TIP\{81D4E9C9-1D3B-41BC-9E6C-4B40BF79E35E}\LanguageProfile\0x00000804\{FA550B04-5AD7-411F-A5AC-CA038EC515D7}","Enable",1
+
+RegWrite,HKLM,0x4,"Tmp_Default\Software\Microsoft\InputMethod\Settings\CHS","Default Mode",1
+RegWrite,HKLM,0x4,"Tmp_Default\Software\Microsoft\InputMethod\Settings\CHS","EnableUMode",1
+RegWrite,HKLM,0x4,"Tmp_Default\Software\Microsoft\InputMethod\Settings\CHS","EnableVMode",1
 
 [#Process-zh-TW#]
 // ===============================================================================================================================

--- a/Projects/PhoenixPE/Tweaks/411-IME.script
+++ b/Projects/PhoenixPE/Tweaks/411-IME.script
@@ -139,6 +139,7 @@ Echo,"Building a list of required files...#$x#$xThis can take awhile, please be 
 // Common IME Files
 
 RequireFileEx,AppendList,\Windows\IME\SPTIP.DLL
+RequireFileEx,AppendList,\Windows\IME\??-??\SpTip.dll.mui
 RequireFileEx,AppendList,\Windows\System32\IME\SHARED\
 RequireFileEx,AppendList,\Windows\System32\InputMethod\SHARED
 If,%SourceVer%,BiggerEqual,10.0.18362,RequireFileEx,AppendList,\Windows\System32\clbcatq.dll
@@ -173,6 +174,17 @@ If,%SourceVer%,BiggerEqual,10.0.18363,RequireFileEx,AppendList,\Windows\System32
 RequireFileEx,AppendList,\Windows\System32\Winlangdb.dll
 RequireFileEx,AppendList,\Windows\System32\Winsta.dll
 If,%SourceVer%,BiggerEqual,10.0.18362,RequireFileEx,AppendList,\Windows\System32\WordBreakers.dll
+If,%SourceVer%,BiggerEqual,10.0.20251,RequireFileEx,AppendList,\Windows\System32\ime_textinputhelpers.dll
+If,%SourceVer%,BiggerEqual,10.0.26100,RequireFileEx,AppendList,\Windows\SystemApps\MicrosoftWindows.Client.Core_cw5n1h2txyewy\SystemTray\Assets\AXPIcons.ttf
+
+If,ExistFile,"%TargetSystem32%\InputService.dll",Begin
+  Echo,"Patching InputService..."
+  FileVersion,"%TargetSystem32%\InputService.dll",%InputServiceVersion%
+  If,%InputServiceVersion%,Bigger,10.0.18300,Begin
+    ShellExecute,Hide,"%Tools%\%HostArch%\binmay.exe","-v -u #$q%TargetSystem32%\InputService.dll#$q -s u:MiniNT -r u:NiniNT"
+    If,Not,#r,Equal,0,Echo,"ERROR: Patching [%TargetSystem32%\InputService.dll] failed. IME may not be available. The error returned was [#r].",WARN
+  End
+End
 
 ///////////////////////////////////////////////////////////////////////////////////
 // WoW64 


### PR DESCRIPTION
The patch is taken from [wimbuilder2](https://github.com/slorelee/wimbuilder2/blob/master/Projects/WIN10XPE/01-Components/IME/last.bat)

<details>
<summary>Outdated</summary>
I was still unable to get the candidate window to show up. But at least it now shows word splitter.

Before
![0e4da6fa7711f703029838c481033f36](https://github.com/user-attachments/assets/70186154-11a5-4a57-80c6-091ed28de787)
After:
![c2c3c0a721d7478248d3185e5ed1ebc7](https://github.com/user-attachments/assets/6afe4e45-6806-44d3-9c62-e10dcac36116)

</details>