### PR TITLE
Include USB Audio 2.0 driver

### DIFF
--- a/Projects/PhoenixPE/Components/320-Audio.script
+++ b/Projects/PhoenixPE/Components/320-Audio.script
@@ -35,8 +35,8 @@ Author=Homes32
 Level=4
 Selected=True
 Mandatory=False
-Version=1.2.1.0
-Date=2024-01-12
+Version=1.3.0.0
+Date=2025-03-16
 
 [Variables]
 
@@ -133,10 +133,12 @@ RequireFileEx,AppendList,\Windows\INF\ks.inf,NOMUI
 RequireFileEx,AppendList,\Windows\INF\kscaptur.inf,NOMUI
 RequireFileEx,AppendList,\Windows\INF\ksfilter.inf,NOMUI
 RequireFileEx,AppendList,\Windows\INF\modemcsa.inf,NOMUI
+If,%SourceVer%,BiggerEqual,10.0.15063.0,RequireFileEx,AppendList,\Windows\INF\usbaudio2.inf,NOMUI
 RequireFileEx,AppendList,\Windows\INF\usbvideo.inf,NOMUI
 RequireFileEx,AppendList,\Windows\INF\wave.inf,NOMUI
 
 RequireFileEx,AppendList,\Windows\System32\drivers\beep.sys,NOMUI
+If,%SourceVer%,BiggerEqual,10.0.15063.0,RequireFileEx,AppendList,\Windows\System32\drivers\usbaudio2.sys,NOMUI
 
 RequireFileEx,AppendList,\Windows\System32\DriverStore\FileRepository\bda.inf*,NOMUI
 RequireFileEx,AppendList,\Windows\System32\DriverStore\FileRepository\c_media.inf*,NOMUI
@@ -145,6 +147,7 @@ RequireFileEx,AppendList,\Windows\System32\DriverStore\FileRepository\ks.inf*,NO
 RequireFileEx,AppendList,\Windows\System32\DriverStore\FileRepository\kscaptur.inf*,NOMUI
 RequireFileEx,AppendList,\Windows\System32\DriverStore\FileRepository\ksfilter.inf*,NOMUI
 RequireFileEx,AppendList,\Windows\System32\DriverStore\FileRepository\modemcsa.inf*,NOMUI
+If,%SourceVer%,BiggerEqual,10.0.15063.0,RequireFileEx,AppendList,\Windows\System32\DriverStore\FileRepository\usbaudio2.inf*,NOMUI
 RequireFileEx,AppendList,\Windows\System32\DriverStore\FileRepository\usbvideo.inf*,NOMUI
 RequireFileEx,AppendList,\Windows\System32\DriverStore\FileRepository\wave.inf*,NOMUI
 


### PR DESCRIPTION
Let's include the usbaudio2.sys driver to enable USB Audio 2.0 compatible sound cards as most of the more recent USB sound cards don't work without it.

This feature was introduced in Windows 10 1703 (build 15063)
- see https://learn.microsoft.com/en-us/windows-hardware/drivers/audio/usb-2-0-audio-drivers for more information.