### PR TITLE
Updates for Chrome and .NET

### DIFF
--- a/Projects/PhoenixPE/Applications/Networking/Chrome.script
+++ b/Projects/PhoenixPE/Applications/Networking/Chrome.script
@@ -30,19 +30,19 @@
 
 [Main]
 Title=Google Chrome
-Description=(v136.0.7103.93) Google Chrome is a cross-platform web browser developed by Google.
+Description=(v138.0.7204.50) Google Chrome is a cross-platform web browser developed by Google.
 Author=Homes32
 Level=5
 Selected=False
 Mandatory=False
-Version=1.1.18.0
-Date=2025-05-14
+Version=1.1.19.0
+Date=2025-06-25
 
 [Variables]
 %ProgramFolder%="Chrome"
 %ProgramExe%="chrome.exe"
-%DownloadURLx86%=https://dl.google.com/release2/chrome/acnr5b6bwpsrgcvxxz5hakjvniia_136.0.7103.93/136.0.7103.93_chrome_installer.exe
-%DownloadURLx64%=https://dl.google.com/release2/chrome/acmbkhjxay4eqmo7yutbo43vubca_136.0.7103.93/136.0.7103.93_chrome_installer.exe
+%DownloadURLx86%=https://dl.google.com/release2/chrome/j3u7wrnak5a2hjrnzarf4cas3i_138.0.7204.50/138.0.7204.50_chrome_installer_uncompressed.exe
+%DownloadURLx64%=https://dl.google.com/release2/chrome/o6dbyytvo73aj3atmz5ua7m6ry_138.0.7204.50/138.0.7204.50_chrome_installer_uncompressed.exe
 %SetupFile%="Chrome_x86.exe"
 
 [Process]
@@ -58,7 +58,6 @@ If,Not,ExistFile,"%ProgramsCache%\%ProgramFolder%\%SetupFile%",Run,%ScriptFile%,
 Echo,"Extracting files..."
 DirMake,"%TargetPrograms%\%ProgramFolder%"
 Decompress,"%ProgramsCache%\%ProgramFolder%\%SetupFile%","%ProjectTemp%\%ProgramFolder%"
-Decompress,"%ProjectTemp%\%ProgramFolder%\chrome.7z","%ProjectTemp%\%ProgramFolder%"
 FileCopy,"%ProjectTemp%\%ProgramFolder%\Chrome-bin\*.*","%TargetPrograms%\%ProgramFolder%"
 
 ///////////////////////////////////////////////////////////////////////////////////

--- a/Projects/PhoenixPE/Applications/Networking/Chrome.script
+++ b/Projects/PhoenixPE/Applications/Networking/Chrome.script
@@ -30,7 +30,7 @@
 
 [Main]
 Title=Google Chrome
-Description=(v138.0.7204.50) Google Chrome is a cross-platform web browser developed by Google.
+Description=(v138.0.7204.97) Google Chrome is a cross-platform web browser developed by Google.
 Author=Homes32
 Level=5
 Selected=False
@@ -41,8 +41,8 @@ Date=2025-06-25
 [Variables]
 %ProgramFolder%="Chrome"
 %ProgramExe%="chrome.exe"
-%DownloadURLx86%=https://dl.google.com/release2/chrome/j3u7wrnak5a2hjrnzarf4cas3i_138.0.7204.50/138.0.7204.50_chrome_installer_uncompressed.exe
-%DownloadURLx64%=https://dl.google.com/release2/chrome/o6dbyytvo73aj3atmz5ua7m6ry_138.0.7204.50/138.0.7204.50_chrome_installer_uncompressed.exe
+%DownloadURLx86%=https://dl.google.com/release2/chrome/ac4d4vq6w323vk5y57jetvjiqzjq_138.0.7204.97/138.0.7204.97_chrome_installer_uncompressed.exe
+%DownloadURLx64%=https://dl.google.com/release2/chrome/acfputsgwfhpt46zcvjobof6evfq_138.0.7204.97/138.0.7204.97_chrome_installer_uncompressed.exe
 %SetupFile%="Chrome_x86.exe"
 
 [Process]

--- a/Projects/PhoenixPE/Components/.NET Runtime/DotNET5.script
+++ b/Projects/PhoenixPE/Components/.NET Runtime/DotNET5.script
@@ -34,8 +34,8 @@ Description=(v5.0.17) .NET 5 is a cross-platform software development framework 
 Selected=False
 Level=4
 Author=Homes32
-Version=1.0.0.0
-Date=2024-07-05
+Version=1.0.1.0
+Date=2025-06-25
 Mandatory=False
 
 [Variables]
@@ -75,9 +75,13 @@ RegWrite,HKLM,0x2,"Tmp_System\ControlSet001\Control\Session Manager\Environment"
 If,%SourceArch%,Equal,x64,Begin
   RegWrite,HKLM,0x4,"Tmp_Software\dotnet\Setup\InstalledVersions\x64",%ProgramVersion%,1
   RegWrite,HKLM,0x1,"Tmp_Software\WOW6432Node\dotnet\Setup\InstalledVersions\x64","InstallLocation","%PEPrograms%\dotnet\"
+  RegWrite,HKLM,0x4,"Tmp_Software\WOW6432Node\dotnet\Setup\InstalledVersions\x64\sharedfx\Microsoft.NETCore.App",%ProgramVersion%,1
+  RegWrite,HKLM,0x4,"Tmp_Software\WOW6432Node\dotnet\Setup\InstalledVersions\x64\sharedfx\Microsoft.WindowsDesktop.App",%ProgramVersion%,1
 End
 Else,Begin
   RegWrite,HKLM,0x4,"Tmp_Software\dotnet\Setup\InstalledVersions\x86",%ProgramVersion%,1
+  RegWrite,HKLM,0x4,"Tmp_Software\dotnet\Setup\InstalledVersions\x86\sharedfx\Microsoft.NETCore.App",%ProgramVersion%,1
+  RegWrite,HKLM,0x4,"Tmp_Software\dotnet\Setup\InstalledVersions\x86\sharedfx\Microsoft.WindowsDesktop.App",%ProgramVersion%,1
 End
 
 RegUnloadHives

--- a/Projects/PhoenixPE/Components/.NET Runtime/DotNET6.script
+++ b/Projects/PhoenixPE/Components/.NET Runtime/DotNET6.script
@@ -34,8 +34,8 @@ Description=(v6.0.36) .NET 6 is a cross-platform software development framework 
 Selected=False
 Level=4
 Author=Homes32
-Version=1.0.12.0
-Date=2024-12-14
+Version=1.0.13.0
+Date=2025-06-25
 Mandatory=False
 
 [Variables]
@@ -75,9 +75,13 @@ RegWrite,HKLM,0x2,"Tmp_System\ControlSet001\Control\Session Manager\Environment"
 If,%SourceArch%,Equal,x64,Begin
   RegWrite,HKLM,0x4,"Tmp_Software\dotnet\Setup\InstalledVersions\x64",%ProgramVersion%,1
   RegWrite,HKLM,0x1,"Tmp_Software\WOW6432Node\dotnet\Setup\InstalledVersions\x64","InstallLocation","%PEPrograms%\dotnet\"
+  RegWrite,HKLM,0x4,"Tmp_Software\WOW6432Node\dotnet\Setup\InstalledVersions\x64\sharedfx\Microsoft.NETCore.App",%ProgramVersion%,1
+  RegWrite,HKLM,0x4,"Tmp_Software\WOW6432Node\dotnet\Setup\InstalledVersions\x64\sharedfx\Microsoft.WindowsDesktop.App",%ProgramVersion%,1
 End
 Else,Begin
   RegWrite,HKLM,0x4,"Tmp_Software\dotnet\Setup\InstalledVersions\x86",%ProgramVersion%,1
+  RegWrite,HKLM,0x4,"Tmp_Software\dotnet\Setup\InstalledVersions\x86\sharedfx\Microsoft.NETCore.App",%ProgramVersion%,1
+  RegWrite,HKLM,0x4,"Tmp_Software\dotnet\Setup\InstalledVersions\x86\sharedfx\Microsoft.WindowsDesktop.App",%ProgramVersion%,1
 End
 
 RegUnloadHives

--- a/Projects/PhoenixPE/Components/.NET Runtime/DotNET7.script
+++ b/Projects/PhoenixPE/Components/.NET Runtime/DotNET7.script
@@ -34,8 +34,8 @@ Description=(v7.0.20) .NET 7 is a cross-platform software development framework 
 Selected=False
 Level=4
 Author=Homes32
-Version=1.0.0.0
-Date=2024-07-05
+Version=1.0.1.0
+Date=2025-06-25
 Mandatory=False
 
 [Variables]
@@ -75,9 +75,13 @@ RegWrite,HKLM,0x2,"Tmp_System\ControlSet001\Control\Session Manager\Environment"
 If,%SourceArch%,Equal,x64,Begin
   RegWrite,HKLM,0x4,"Tmp_Software\dotnet\Setup\InstalledVersions\x64",%ProgramVersion%,1
   RegWrite,HKLM,0x1,"Tmp_Software\WOW6432Node\dotnet\Setup\InstalledVersions\x64","InstallLocation","%PEPrograms%\dotnet\"
+  RegWrite,HKLM,0x4,"Tmp_Software\WOW6432Node\dotnet\Setup\InstalledVersions\x64\sharedfx\Microsoft.NETCore.App",%ProgramVersion%,1
+  RegWrite,HKLM,0x4,"Tmp_Software\WOW6432Node\dotnet\Setup\InstalledVersions\x64\sharedfx\Microsoft.WindowsDesktop.App",%ProgramVersion%,1
 End
 Else,Begin
   RegWrite,HKLM,0x4,"Tmp_Software\dotnet\Setup\InstalledVersions\x86",%ProgramVersion%,1
+  RegWrite,HKLM,0x4,"Tmp_Software\dotnet\Setup\InstalledVersions\x86\sharedfx\Microsoft.NETCore.App",%ProgramVersion%,1
+  RegWrite,HKLM,0x4,"Tmp_Software\dotnet\Setup\InstalledVersions\x86\sharedfx\Microsoft.WindowsDesktop.App",%ProgramVersion%,1
 End
 
 RegUnloadHives

--- a/Projects/PhoenixPE/Components/.NET Runtime/DotNET8.script
+++ b/Projects/PhoenixPE/Components/.NET Runtime/DotNET8.script
@@ -34,14 +34,14 @@ Selected=False
 Description=(v8.0.16) .NET 8 is a cross-platform software development framework for building and running applications.
 Level=4
 Author=Homes32
-Version=1.0.6.0
+Version=1.0.7.0
 Date=2025-06-01
 Mandatory=False
 
 [Variables]
 %ProgramTitle%=".NET 8 Desktop Runtime"
 %ProgramFolder%="dotnet"
-%ProgramVersion%="8.0.16"
+%ProgramVersion%="8.0.17"
 %DownloadURLx86%=https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/%ProgramVersion%/windowsdesktop-runtime-%ProgramVersion%-win-x86.exe
 %DownloadURLx64%=https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/%ProgramVersion%/windowsdesktop-runtime-%ProgramVersion%-win-x64.exe
 
@@ -75,9 +75,13 @@ RegWrite,HKLM,0x2,"Tmp_System\ControlSet001\Control\Session Manager\Environment"
 If,%SourceArch%,Equal,x64,Begin
   RegWrite,HKLM,0x4,"Tmp_Software\dotnet\Setup\InstalledVersions\x64",%ProgramVersion%,1
   RegWrite,HKLM,0x1,"Tmp_Software\WOW6432Node\dotnet\Setup\InstalledVersions\x64","InstallLocation","%PEPrograms%\dotnet\"
+  RegWrite,HKLM,0x4,"Tmp_Software\WOW6432Node\dotnet\Setup\InstalledVersions\x64\sharedfx\Microsoft.NETCore.App",%ProgramVersion%,1
+  RegWrite,HKLM,0x4,"Tmp_Software\WOW6432Node\dotnet\Setup\InstalledVersions\x64\sharedfx\Microsoft.WindowsDesktop.App",%ProgramVersion%,1
 End
 Else,Begin
   RegWrite,HKLM,0x4,"Tmp_Software\dotnet\Setup\InstalledVersions\x86",%ProgramVersion%,1
+  RegWrite,HKLM,0x4,"Tmp_Software\dotnet\Setup\InstalledVersions\x86\sharedfx\Microsoft.NETCore.App",%ProgramVersion%,1
+  RegWrite,HKLM,0x4,"Tmp_Software\dotnet\Setup\InstalledVersions\x86\sharedfx\Microsoft.WindowsDesktop.App",%ProgramVersion%,1
 End
 
 RegUnloadHives

--- a/Projects/PhoenixPE/Components/.NET Runtime/DotNET9.script
+++ b/Projects/PhoenixPE/Components/.NET Runtime/DotNET9.script
@@ -30,18 +30,18 @@
 
 [Main]
 Title=.NET 9
-Description=(v9.0.5) .NET 9 is a cross-platform software development framework for building and running applications.
+Description=(v9.0.6) .NET 9 is a cross-platform software development framework for building and running applications.
 Selected=False
 Level=4
 Author=Homes32
-Version=1.0.3.0
+Version=1.0.4.0
 Date=2025-06-01
 Mandatory=False
 
 [Variables]
 %ProgramTitle%=".NET 9 Desktop Runtime"
 %ProgramFolder%="dotnet"
-%ProgramVersion%="9.0.5"
+%ProgramVersion%="9.0.6"
 %DownloadURLx86%=https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/%ProgramVersion%/windowsdesktop-runtime-%ProgramVersion%-win-x86.exe
 %DownloadURLx64%=https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/%ProgramVersion%/windowsdesktop-runtime-%ProgramVersion%-win-x64.exe
 
@@ -75,9 +75,13 @@ RegWrite,HKLM,0x2,"Tmp_System\ControlSet001\Control\Session Manager\Environment"
 If,%SourceArch%,Equal,x64,Begin
   RegWrite,HKLM,0x4,"Tmp_Software\dotnet\Setup\InstalledVersions\x64",%ProgramVersion%,1
   RegWrite,HKLM,0x1,"Tmp_Software\WOW6432Node\dotnet\Setup\InstalledVersions\x64","InstallLocation","%PEPrograms%\dotnet\"
+  RegWrite,HKLM,0x4,"Tmp_Software\WOW6432Node\dotnet\Setup\InstalledVersions\x64\sharedfx\Microsoft.NETCore.App",%ProgramVersion%,1
+  RegWrite,HKLM,0x4,"Tmp_Software\WOW6432Node\dotnet\Setup\InstalledVersions\x64\sharedfx\Microsoft.WindowsDesktop.App",%ProgramVersion%,1
 End
 Else,Begin
   RegWrite,HKLM,0x4,"Tmp_Software\dotnet\Setup\InstalledVersions\x86",%ProgramVersion%,1
+  RegWrite,HKLM,0x4,"Tmp_Software\dotnet\Setup\InstalledVersions\x86\sharedfx\Microsoft.NETCore.App",%ProgramVersion%,1
+  RegWrite,HKLM,0x4,"Tmp_Software\dotnet\Setup\InstalledVersions\x86\sharedfx\Microsoft.WindowsDesktop.App",%ProgramVersion%,1
 End
 
 RegUnloadHives


### PR DESCRIPTION
#### Update Chrome and remove decompressing step
My source of chrome installer is https://github.com/Bush2021/chrome_installer, and in the recent 2 versions it started shipping "uncompressed" installers so I think there's now one less step

#### .NET
Update version and add registries to fix PEBakery launcher not detecting the runtime